### PR TITLE
Switch from deprecated Symbol type to string

### DIFF
--- a/lib/mongoid/enum_attribute.rb
+++ b/lib/mongoid/enum_attribute.rb
@@ -98,20 +98,20 @@ module Mongoid
 
       def define_array_field_accessor(name, field_name)
         class_eval "def #{name}=(vals) self.write_attribute(:#{field_name}, Array(vals).compact.map(&:to_sym)) end"
-        class_eval "
-          def #{name}()
-            return self.send(:#{field_name}).map{ |i| i.try(:to_sym) } if name != field_name
-            field_name.map{ |i| i.try(:to_sym) }
-          end"
+        if name != field_name
+          class_eval "def #{name}() self.send(:#{field_name}).map{ |i| i.try(:to_sym) } end"
+        else
+          class_eval "def #{name}() self.field_name.map{ |i| i.try(:to_sym) } end"
+        end
       end
 
       def define_string_field_accessor(name, field_name)
         class_eval "def #{name}=(val) self.write_attribute(:#{field_name}, val && val.to_sym || nil) end"
-        class_eval "
-          def #{name}()
-            return self.send(:#{field_name}).to_sym if name != field_name
-            field_name.to_sym
-          end"
+        if name != field_name
+          class_eval "def #{name}() self.send(:#{field_name}).to_sym end"
+        else
+          class_eval "def #{name}() self.field_name.to_sym end"
+        end
       end
 
       def define_array_accessor(accessor_name, field_name, value)

--- a/lib/mongoid/enum_attribute.rb
+++ b/lib/mongoid/enum_attribute.rb
@@ -37,7 +37,7 @@ module Mongoid
       end
 
       def create_field(field_name, options)
-        type = options[:multiple] && Array || Symbol
+        type = options[:multiple] && Array || String
         field field_name, type: type, default: options[:default]
       end
 

--- a/lib/mongoid/enum_attribute.rb
+++ b/lib/mongoid/enum_attribute.rb
@@ -53,7 +53,7 @@ module Mongoid
         elsif options[:validate]
           validates(
             field_name,
-            inclusion: { in: values.map(&:to_sym) },
+            inclusion: { in: values.map(&:to_s) },
             allow_nil: !options[:required]
           )
         end

--- a/lib/mongoid/enum_attribute.rb
+++ b/lib/mongoid/enum_attribute.rb
@@ -8,11 +8,11 @@ module Mongoid
 
     module ClassMethods
       def enum(name, values, options = {})
-        field_name = "#{Mongoid::EnumAttribute.configuration.field_name_prefix}#{name}"
+        field_name = name.to_s
         options = default_options(values).merge(options)
 
         set_values_constant(name, values)
-        create_field(field_name, options)
+        field_name = create_field(field_name, options)
 
         create_validations(field_name, values, options)
         define_value_scopes_and_accessors(name, field_name, values, options)
@@ -27,7 +27,8 @@ module Mongoid
           required: true,
           validate: true,
           prefix: Mongoid::EnumAttribute.configuration.prefix,
-          suffix: Mongoid::EnumAttribute.configuration.suffix
+          suffix: Mongoid::EnumAttribute.configuration.suffix,
+          field_name_prefix: Mongoid::EnumAttribute.configuration.field_name_prefix
         }
       end
 
@@ -38,7 +39,9 @@ module Mongoid
 
       def create_field(field_name, options)
         type = options[:multiple] && Array || String
+        field_name = "#{options[:field_name_prefix]}#{name}"
         field field_name, type: type, default: options[:default]
+        field_name
       end
 
       def create_validations(field_name, values, options)

--- a/lib/mongoid/enum_attribute.rb
+++ b/lib/mongoid/enum_attribute.rb
@@ -39,7 +39,7 @@ module Mongoid
 
       def create_field(name, options)
         type = options[:multiple] && Array || String
-        field_name = options[:field_name].to_s || "#{options[:field_name_prefix]}#{name}"
+        field_name = (options[:field_name] || "#{options[:field_name_prefix]}#{name}").to_s
         raise "enum name #{name} and field_name option cannot be equal!" if name.to_s == field_name.to_s
         field field_name, type: type, default: options[:default]
         field_name

--- a/lib/mongoid/enum_attribute.rb
+++ b/lib/mongoid/enum_attribute.rb
@@ -39,7 +39,7 @@ module Mongoid
 
       def create_field(field_name, options)
         type = options[:multiple] && Array || String
-        field_name = "#{options[:field_name_prefix]}#{name}"
+        field_name = "#{options[:field_name_prefix]}#{field_name}"
         field field_name, type: type, default: options[:default]
         field_name
       end
@@ -98,12 +98,20 @@ module Mongoid
 
       def define_array_field_accessor(name, field_name)
         class_eval "def #{name}=(vals) self.write_attribute(:#{field_name}, Array(vals).compact.map(&:to_sym)) end"
-        class_eval "def #{name}() self.send(:#{field_name}).map{ |i| i.try(:to_sym) } end"
+        class_eval "
+          def #{name}()
+            return self.send(:#{field_name}).map{ |i| i.try(:to_sym) } if name != field_name
+            field_name.map{ |i| i.try(:to_sym) }
+          end"
       end
 
       def define_string_field_accessor(name, field_name)
         class_eval "def #{name}=(val) self.write_attribute(:#{field_name}, val && val.to_sym || nil) end"
-        class_eval "def #{name}() self.send(:#{field_name}).to_sym end"
+        class_eval "
+          def #{name}()
+            return self.send(:#{field_name}).to_sym if name != field_name
+            field_name.to_sym
+          end"
       end
 
       def define_array_accessor(accessor_name, field_name, value)

--- a/lib/mongoid/enum_attribute.rb
+++ b/lib/mongoid/enum_attribute.rb
@@ -100,7 +100,7 @@ module Mongoid
 
       def define_string_field_accessor(name, field_name)
         class_eval "def #{name}=(val) self.write_attribute(:#{field_name}, val && val.to_sym || nil) end"
-        class_eval "def #{name}() self.send(:#{field_name}) end"
+        class_eval "def #{name}() self.send(:#{field_name}).to_sym end"
       end
 
       def define_array_accessor(accessor_name, field_name, value)
@@ -109,7 +109,7 @@ module Mongoid
       end
 
       def define_string_accessor(accessor_name, field_name, value)
-        class_eval "def #{accessor_name}?() self.#{field_name} == :#{value} end"
+        class_eval "def #{accessor_name}?() self.#{field_name}.to_sym == :#{value} end"
         class_eval "def #{accessor_name}!() update_attributes! :#{field_name} => :#{value} end"
       end
     end

--- a/mongoid-enum_attribute.gemspec
+++ b/mongoid-enum_attribute.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'mongoid', '>= 5', '< 8'
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "database_cleaner"

--- a/test/mongoid/enum_attribute_test.rb
+++ b/test/mongoid/enum_attribute_test.rb
@@ -17,7 +17,7 @@ describe Mongoid::EnumAttribute do
 
     describe "type" do
       describe "multiple: false" do
-        it { kls.fields[field_name].options[:type].must_equal Symbol }
+        it { kls.fields[field_name].options[:type].must_equal String }
         it { kls._validators[field_name.to_sym].first.must_be_kind_of ActiveModel::Validations::InclusionValidator }
       end
 


### PR DESCRIPTION
Mongo DB has deprecated [Symbol type](https://docs.mongodb.com/manual/reference/bson-types/). This patch will allow to use this gem with further MongoDB versions, maintaining backward compatibility with previous gem versions
